### PR TITLE
Simplify installation

### DIFF
--- a/crustacea/src/editor.py
+++ b/crustacea/src/editor.py
@@ -22,6 +22,7 @@ class EditorScreen(Screen):
         ("ctrl+r", "auto_return", "Enable Automatic Return"),
         ("ctrl+t", "auto_tab", "Disable Automatic Tab"),
         ("ctrl+n", "cursor_navigation", "Enable Cursor Navigation"),
+        ("ctrl+o", "back_to_menu", "Back to FileMenu"),
     ]
 
     time_elapsed = Reactive(0.00001)
@@ -101,3 +102,9 @@ class EditorScreen(Screen):
         '''enable the navigation with arrow keys in the code editor'''
         self.enable_arrow_keys = not self.enable_arrow_keys        
         ic(f"Toggle CURSOR Navigation into {self.enable_arrow_keys}")
+        
+    def action_back_to_menu(self):
+        '''switch back to the file selection menu screen'''
+        self.app._driver._enable_mouse_support()
+        self.app.push_screen(self.app.file_menu)
+        ic(f"Switch back to the file selection menu.")

--- a/crustacea/src/filemenu.py
+++ b/crustacea/src/filemenu.py
@@ -2,12 +2,13 @@ from textual.app import ComposeResult
 from textual.screen import Screen
 from textual.widgets import Header, Footer, RadioSet, RadioButton, Button
 from pathlib import Path
+from textual.binding import Binding
 
 from crustacea.src.editor import EditorScreen
 from crustacea.src.language_map import language_map
 
 
-text_folder = Path("./crustacea/texts")
+text_folder = Path(__file__).parents[1] / "texts"
 
 class FileMenuScreen(Screen):
     
@@ -24,6 +25,12 @@ class FileMenuScreen(Screen):
         margin-right: 3;
     }
     """
+    
+    BINDINGS = [
+        Binding("ctrl+q", "quit", "Quit", 
+                tooltip="Quit the app and return to the command prompt.", 
+                show=True, priority=True),
+    ]
     
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)

--- a/crustacea/src/results_storage.py
+++ b/crustacea/src/results_storage.py
@@ -1,11 +1,12 @@
 import sqlite3
+from pathlib import Path
 
 class StorageContext:
-    def __init__(self, db_path="./crustacea/db/crust.db"):
+    def __init__(self):
         """
         This Class provide access to the sqlite database where all statistics from the training were stored
         """
-        self.db_path = db_path
+        self.db_path = Path(__file__).parents[1] / "db" / "crust.db"
 
     def __enter__(self):
         # Create a connection to the database

--- a/crustacea/src/results_visualization.py
+++ b/crustacea/src/results_visualization.py
@@ -3,6 +3,8 @@ from textual.app import ComposeResult
 from textual.screen import Screen
 from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Static
+from textual.binding import Binding
+from textual.widgets import Footer
 
 from crustacea.src.results_storage import StorageContext
 from crustacea.src.results_sparkline import StatisticHorizontal
@@ -42,6 +44,13 @@ class ResultVisualization(Screen):
             width: 20%;
         }
     """
+    
+    BINDINGS = [
+        Binding("ctrl+q", "quit", "Quit", 
+                tooltip="Quit the app and return to the command prompt.", 
+                show=True, priority=True),
+        ("ctrl+o", "back_to_menu", "Back to FileMenu"),
+    ]
 
 
     def compose(self) -> ComposeResult:
@@ -68,6 +77,7 @@ class ResultVisualization(Screen):
                 "Char Counter", "Error Counter", "Error Rate (%)", "Char/min", "Score"
                 ]):
                 yield StatisticHorizontal(result_name, self.get_data_for(result_name))
+        yield Footer()
 
         
     def get_data_for(self, result_name):
@@ -79,5 +89,11 @@ class ResultVisualization(Screen):
             # transform the sqlite data into a plain list
             data = [row[0] for row in sqlite_response]
         return data
+    
+    def action_back_to_menu(self):
+        '''switch back to the file selection menu screen'''
+        self.app._driver._enable_mouse_support()
+        self.app.push_screen(self.app.file_menu)
+
         
             

--- a/crustacea/src/text_area.py
+++ b/crustacea/src/text_area.py
@@ -35,6 +35,7 @@ class CrustaceaTextArea(widg.TextArea):
         if event.is_printable or event.key in self.insert_values:
             event.stop()
             event.prevent_default()
+            self._restart_blink()
             insert = self.insert_values.get(event.key, event.character)
 
             current_row, current_col = self.cursor_location
@@ -162,3 +163,4 @@ class CrustaceaTextArea(widg.TextArea):
     def action_cursor_line_start(self, select: bool = False) -> None:
         if self.screen.enable_arrow_keys:
             super().action_cursor_line_start(select)
+            

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crustacea"
-version = "1.1.0"
+version = "1.2.0"
 description = ""
 authors = [{ name = "Manuel Schenk" }]
 readme = "README.md"
@@ -19,7 +19,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "crustacea"
-version = "1.1.0"
+version = "1.2.0"
 description = ""
 authors = ["Manuel Schenk"]
 readme = "README.md"


### PR DESCRIPTION
- use relative paths so that the db and train texts are available after pip installation
- improve cursor visibility
- add "back to file menu" keybinding to all screens